### PR TITLE
Clang tidy modernize checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 ---
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
 Checks: 'modernize-*,-modernize-use-trailing-return-type,
-    readability-*,-readability-magic-numbers'
+    readability-*,-readability-magic-numbers,
+    portability-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,13 @@ Checks: 'modernize-use-nodiscard,
     modernize-loop-convert,
     modernize-make-shared,
     modernize-make-unique,
-    modernize-pass-by-value'
+    modernize-pass-by-value,
+    modernize-raw-string-literal,
+    modernize-redundant-void-arg,
+    modernize-replace-auto-ptr,
+    modernize-replace-disallow-copy-and-assign-macro,
+    modernize-replace-random-shuffle,
+    modernize-*,-modernize-use-trailing-return-type'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     portability-*,
     cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes,
     bugprone-*,
-    cert-*'
+    cert-*,
+    clang-analyzer-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,7 @@
 Checks: 'modernize-*,-modernize-use-trailing-return-type,
     readability-*,-readability-magic-numbers,
     portability-*,
-    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers'
+    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     cert-*,
     clang-analyzer-*,
     concurrency-*,openmp-*,
-    misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion'
+    misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion,
+    objc-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion,
     objc-*,
     mpi-*,
-    performance-*'
+    performance-*,
+    hicpp-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,22 +1,6 @@
 ---
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
-Checks: 'modernize-use-nodiscard,
-    modernize-use-noexcept,
-    modernize-avoid-bind,
-    modernize-avoid-c-arrays,
-    modernize-concat-nested-namespaces,
-    modernize-deprecated-headers,
-    modernize-deprecated-ios-base-aliases,
-    modernize-loop-convert,
-    modernize-make-shared,
-    modernize-make-unique,
-    modernize-pass-by-value,
-    modernize-raw-string-literal,
-    modernize-redundant-void-arg,
-    modernize-replace-auto-ptr,
-    modernize-replace-disallow-copy-and-assign-macro,
-    modernize-replace-random-shuffle,
-    modernize-*,-modernize-use-trailing-return-type'
+Checks: 'modernize-*,-modernize-use-trailing-return-type'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
-Checks: 'modernize-*,-modernize-use-trailing-return-type'
+Checks: 'modernize-*,-modernize-use-trailing-return-type,
+    readability-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     performance-*,
     hicpp-*,
     llvm-*,-llvm-header-guard,
-    llvmlibc-*'
+    -llvmlibc-*,
+    google-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     objc-*,
     mpi-*,
     performance-*,
-    hicpp-*'
+    hicpp-*,
+    llvm-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
 Checks: 'modernize-*,-modernize-use-trailing-return-type,
-    readability-*'
+    readability-*,-readability-magic-numbers'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,16 @@
 ---
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
-Checks: 'modernize-use-nodiscard,modernize-use-noexcept'
+Checks: 'modernize-use-nodiscard,
+    modernize-use-noexcept,
+    modernize-avoid-bind,
+    modernize-avoid-c-arrays,
+    modernize-concat-nested-namespaces,
+    modernize-deprecated-headers,
+    modernize-deprecated-ios-base-aliases,
+    modernize-loop-convert,
+    modernize-make-shared,
+    modernize-make-unique,
+    modernize-pass-by-value'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,7 +3,8 @@
 Checks: 'modernize-*,-modernize-use-trailing-return-type,
     readability-*,-readability-magic-numbers,
     portability-*,
-    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes'
+    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes,
+    bugprone-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     bugprone-*,
     cert-*,
     clang-analyzer-*,
-    concurrency-*,openmp-*'
+    concurrency-*,openmp-*,
+    misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     concurrency-*,openmp-*,
     misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion,
     objc-*,
-    mpi-*'
+    mpi-*,
+    performance-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     clang-analyzer-*,
     concurrency-*,openmp-*,
     misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion,
-    objc-*'
+    objc-*,
+    mpi-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,8 @@
 # Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
 Checks: 'modernize-*,-modernize-use-trailing-return-type,
     readability-*,-readability-magic-numbers,
-    portability-*'
+    portability-*,
+    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,21 +1,11 @@
 ---
-# Checks: '*,-fuchsia-*,-google-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm*'
-Checks: 'modernize-*,-modernize-use-trailing-return-type,
-    readability-*,-readability-magic-numbers,
-    portability-*,
-    cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes,
-    bugprone-*,
-    cert-*,
-    clang-analyzer-*,
-    concurrency-*,openmp-*,
-    misc-*,-misc-non-private-member-variables-in-classes,-misc-no-recursion,
-    objc-*,
-    mpi-*,
-    performance-*,
-    hicpp-*,
-    llvm-*,-llvm-header-guard,
-    -llvmlibc-*,
-    google-*'
+Checks: '*,-fuchsia-*,-zircon-*,-abseil-*,-modernize-use-trailing-return-type,-llvm-header-guard,-llvmlibc-*,
+    -readability-magic-numbers,
+    -cppcoreguidelines-avoid-magic-numbers,
+    -cppcoreguidelines-pro-bounds-constant-array-index,
+    -cppcoreguidelines-non-private-member-variables-in-classes,
+    -misc-non-private-member-variables-in-classes,
+    -misc-no-recursion'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes,
     bugprone-*,
     cert-*,
-    clang-analyzer-*'
+    clang-analyzer-*,
+    concurrency-*,openmp-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     mpi-*,
     performance-*,
     hicpp-*,
-    llvm-*'
+    llvm-*,-llvm-header-guard,
+    llvmlibc-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,7 +4,8 @@ Checks: 'modernize-*,-modernize-use-trailing-return-type,
     readability-*,-readability-magic-numbers,
     portability-*,
     cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-non-private-member-variables-in-classes,
-    bugprone-*'
+    bugprone-*,
+    cert-*'
 WarningsAsErrors: '.*'
 HeaderFilterRegex: '.*'
 FormatStyle: none

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -10,8 +10,8 @@
 
 Ray Camera::rayForPixel(const uint32_t px, const uint32_t py) const noexcept
 {
-    const float xOffset = (static_cast<float>(px) + 0.5f) * pixelSize;
-    const float yOffset = (static_cast<float>(py) + 0.5f) * pixelSize;
+    const float xOffset = (static_cast<float>(px) + 0.5F) * pixelSize;
+    const float yOffset = (static_cast<float>(py) + 0.5F) * pixelSize;
 
     const float worldX = halfWidth - xOffset;
     const float worldY = halfHeight - yOffset;

--- a/src/Camera.hpp
+++ b/src/Camera.hpp
@@ -12,7 +12,6 @@
 #include "Matrix.hpp"
 #include "Ray.hpp"
 #include "World.hpp"
-
 #include <cmath>
 
 class Camera
@@ -26,17 +25,17 @@ class Camera
     float halfWidth;
     float halfHeight;
 
-    Camera(const uint32_t horizontalSize, const uint32_t verticalSize, const float fieldOfView) noexcept : hSize(horizontalSize), vSize(verticalSize), fov(fieldOfView), transform(IdentityMatrix())
+    Camera(uint32_t horizontalSize, uint32_t verticalSize, float fieldOfView) noexcept : hSize(horizontalSize), vSize(verticalSize), fov(fieldOfView), transform(IdentityMatrix())
     {
         const float halfView = std::tan(fov / 2);
         const float aspectRatio = static_cast<float>(hSize) / static_cast<float>(vSize);
         halfWidth = hSize >= vSize ? halfView : halfView * aspectRatio;
         halfHeight = hSize < vSize ? halfView : halfView / aspectRatio;
 
-        pixelSize = halfWidth * 2.0f / static_cast<float>(hSize);
+        pixelSize = halfWidth * 2.0F / static_cast<float>(hSize);
     };
 
-    [[nodiscard]] Ray rayForPixel(const uint32_t x, const uint32_t y) const noexcept;
+    [[nodiscard]] Ray rayForPixel(uint32_t x, uint32_t y) const noexcept;
     [[nodiscard]] Canvas Render(const World& w) const noexcept;
 };
 

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -13,11 +13,11 @@ Canvas::Canvas(const uint32_t widthIn, const uint32_t heightIn) noexcept : width
     this->pixels.reserve(heightIn);
     for (uint32_t row = 0; row < heightIn; row++)
     {
-        this->pixels.push_back(std::vector<Color>());
+        this->pixels.emplace_back(std::vector<Color>());
         this->pixels[row].reserve(widthIn);
         for (uint32_t col = 0; col < widthIn; col++)
         {
-            this->pixels[row].push_back(Color());
+            this->pixels[row].emplace_back(Color());
         }
     }
 }

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -32,7 +32,7 @@ std::string Canvas::GetPPMString() const noexcept
         uint64_t charCount = 0;
         for (const auto& pixel : row)
         {
-            std::string redString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.r * 255.0f)), 0, 255)) + " ";
+            std::string redString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.r * 255.0F)), 0, 255)) + " ";
             if (charCount + redString.length() > 70)
             {
                 ppmData.pop_back();
@@ -42,7 +42,7 @@ std::string Canvas::GetPPMString() const noexcept
             ppmData += redString;
             charCount += redString.length();
 
-            std::string greenString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.g * 255.0f)), 0, 255)) + " ";
+            std::string greenString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.g * 255.0F)), 0, 255)) + " ";
             if (charCount + greenString.length() > 70)
             {
                 ppmData.pop_back();
@@ -52,7 +52,7 @@ std::string Canvas::GetPPMString() const noexcept
             ppmData += greenString;
             charCount += greenString.length();
 
-            std::string blueString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.b * 255.0f)), 0, 255)) + " ";
+            std::string blueString = std::to_string(std::clamp(static_cast<int>(std::round(pixel.b * 255.0F)), 0, 255)) + " ";
             if (charCount + blueString.length() > 70)
             {
                 ppmData.pop_back();

--- a/src/Canvas.hpp
+++ b/src/Canvas.hpp
@@ -19,7 +19,7 @@ class Canvas
     const uint32_t height;
     std::vector<std::vector<Color>> pixels;
 
-    Canvas(const uint32_t widthIn, const uint32_t heightIn) noexcept;
+    Canvas(uint32_t widthIn, uint32_t heightIn) noexcept;
     [[nodiscard]] std::string GetPPMString() const noexcept;
 };
 

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -42,5 +42,5 @@ Color Color::operator*(const Color& other) const noexcept
     return Color(this->r * other.r, this->g * other.g, this->b * other.b);
 }
 
-const Color Color::Black = Color(0.0f, 0.0f, 0.0f);
-const Color Color::White = Color(1.0f, 1.0f, 1.0f);
+const Color Color::Black = Color(0.0F, 0.0F, 0.0F);
+const Color Color::White = Color(1.0F, 1.0F, 1.0F);

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -8,7 +8,7 @@
 #ifndef SRC_COLOR_HPP_
 #define SRC_COLOR_HPP_
 
-#define COLOR_EPSILON 0.001F
+constexpr float COLOR_EPSILON = 0.001F;
 
 class Color
 {

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -13,11 +13,11 @@
 class Color
 {
   public:
-    float r;
-    float g;
-    float b;
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
 
-    Color() noexcept : r(0.0f), g(0.0f), b(0.0f){};
+    Color() noexcept = default;
     Color(float red, float green, float blue) noexcept : r(red), g(green), b(blue){};
 
     // Operator overloads

--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -8,25 +8,25 @@
 #ifndef SRC_COLOR_HPP_
 #define SRC_COLOR_HPP_
 
-#define COLOR_EPSILON 0.001f
+#define COLOR_EPSILON 0.001F
 
 class Color
 {
   public:
-    float r = 0.0f;
-    float g = 0.0f;
-    float b = 0.0f;
+    float r = 0.0F;
+    float g = 0.0F;
+    float b = 0.0F;
 
     Color() noexcept = default;
     Color(float red, float green, float blue) noexcept : r(red), g(green), b(blue){};
 
     // Operator overloads
-    bool operator==(const Color&) const noexcept;
-    bool operator!=(const Color&) const noexcept;
-    Color operator+(const Color&) const noexcept;
-    Color operator-(const Color&) const noexcept;
-    Color operator*(const float) const noexcept;
-    Color operator*(const Color&) const noexcept;
+    bool operator==(const Color& other) const noexcept;
+    bool operator!=(const Color& other) const noexcept;
+    Color operator+(const Color& other) const noexcept;
+    Color operator-(const Color& other) const noexcept;
+    Color operator*(float scalar) const noexcept;
+    Color operator*(const Color& other) const noexcept;
 
     const static Color Black;
     const static Color White;

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -44,12 +44,12 @@ Color Material::light(const Light& light, const Tuple& point, const Tuple& eyeVe
 
 Color Pattern::colorAt(const Tuple& p) const noexcept
 {
-    return f(a, b, p); // ? b : a;
+    return f(a, b, p);
 }
 
 Pattern Pattern::Test() noexcept
 {
-    std::function<Color(const Color&, const Color&, const Tuple&)> f = [](const Color&, const Color&, const Tuple& p) -> Color {
+    std::function<Color(const Color&, const Color&, const Tuple&)> f = []([[maybe_unused]] const Color& aP, [[maybe_unused]] const Color& bP, const Tuple& p) -> Color {
         return Color(p.x, p.y, p.z);
     };
     return Pattern(Color::Black, Color::Black, IdentityMatrix(), f);

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -23,7 +23,7 @@ class Pattern
     Matrix<4> transform;
 
     Pattern() noexcept : a(Color::White), b(Color::Black), transform(IdentityMatrix()), f([](Color, Color, Tuple) { return Color::Black; }){};
-    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, const std::function<Color(const Color&, const Color&, const Tuple&)>& fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(fIn){};
+    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, const std::function<Color(const Color&, const Color&, const Tuple&)> fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(std::move(fIn)){};
     [[nodiscard]] Color colorAt(const Tuple& p) const noexcept;
 
     static Pattern Test() noexcept;

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -23,7 +23,7 @@ class Pattern
     Matrix<4> transform;
 
     Pattern() noexcept : a(Color::White), b(Color::Black), transform(IdentityMatrix()), f([]([[maybe_unused]] Color aF, [[maybe_unused]] Color bF, [[maybe_unused]] Tuple pF) { return Color::Black; }){};
-    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, const std::function<Color(const Color& aF, const Color& bF, const Tuple& pF)> fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(std::move(fIn)){};
+    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, std::function<Color(const Color& aF, const Color& bF, const Tuple& pF)> fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(std::move(fIn)){};
     [[nodiscard]] Color colorAt(const Tuple& p) const noexcept;
 
     static Pattern Test() noexcept;

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -42,15 +42,15 @@ class Material
   public:
     Color color;
     std::optional<Pattern> pattern;
-    float ambient;
-    float diffuse;
-    float specular;
-    float shininess;
-    float reflectivity;
-    float transparency;
-    float refractiveIndex;
+    float ambient = 0.1f;
+    float diffuse = 0.9f;
+    float specular = 0.9f;
+    float shininess = 200.0f;
+    float reflectivity = 0.0f;
+    float transparency = 0.0f;
+    float refractiveIndex = 1.0f;
 
-    Material() noexcept : color(Color(1, 1, 1)), ambient(0.1f), diffuse(0.9f), specular(0.9f), shininess(200.0f), reflectivity(0.0f), transparency(0.0f), refractiveIndex(1.0f){};
+    Material() noexcept : color(Color(1, 1, 1)){};
     Material(const Color& colorIn, const float ambientIn, const float diffuseIn, const float specularIn, const float shininessIn, const float reflectivityIn, const float transparencyIn, const float refractiveIndexIn) noexcept : color(colorIn), ambient(ambientIn), diffuse(diffuseIn), specular(specularIn), shininess(shininessIn), reflectivity(reflectivityIn), transparency(transparencyIn), refractiveIndex(refractiveIndexIn){};
 
     [[nodiscard]] bool operator==(const Material& other) const noexcept;

--- a/src/Material.hpp
+++ b/src/Material.hpp
@@ -22,8 +22,8 @@ class Pattern
     Color b;
     Matrix<4> transform;
 
-    Pattern() noexcept : a(Color::White), b(Color::Black), transform(IdentityMatrix()), f([](Color, Color, Tuple) { return Color::Black; }){};
-    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, const std::function<Color(const Color&, const Color&, const Tuple&)> fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(std::move(fIn)){};
+    Pattern() noexcept : a(Color::White), b(Color::Black), transform(IdentityMatrix()), f([]([[maybe_unused]] Color aF, [[maybe_unused]] Color bF, [[maybe_unused]] Tuple pF) { return Color::Black; }){};
+    Pattern(const Color& aIn, const Color& bIn, const Matrix<4>& transformIn, const std::function<Color(const Color& aF, const Color& bF, const Tuple& pF)> fIn) noexcept : a(aIn), b(bIn), transform(transformIn), f(std::move(fIn)){};
     [[nodiscard]] Color colorAt(const Tuple& p) const noexcept;
 
     static Pattern Test() noexcept;
@@ -40,21 +40,21 @@ class Pattern
 class Material
 {
   public:
-    Color color;
+    Color color = Color::White;
     std::optional<Pattern> pattern;
-    float ambient = 0.1f;
-    float diffuse = 0.9f;
-    float specular = 0.9f;
-    float shininess = 200.0f;
-    float reflectivity = 0.0f;
-    float transparency = 0.0f;
-    float refractiveIndex = 1.0f;
+    float ambient = 0.1F;
+    float diffuse = 0.9F;
+    float specular = 0.9F;
+    float shininess = 200.0F;
+    float reflectivity = 0.0F;
+    float transparency = 0.0F;
+    float refractiveIndex = 1.0F;
 
-    Material() noexcept : color(Color(1, 1, 1)){};
-    Material(const Color& colorIn, const float ambientIn, const float diffuseIn, const float specularIn, const float shininessIn, const float reflectivityIn, const float transparencyIn, const float refractiveIndexIn) noexcept : color(colorIn), ambient(ambientIn), diffuse(diffuseIn), specular(specularIn), shininess(shininessIn), reflectivity(reflectivityIn), transparency(transparencyIn), refractiveIndex(refractiveIndexIn){};
+    Material() noexcept = default;
+    Material(const Color& colorIn, float ambientIn, float diffuseIn, float specularIn, float shininessIn, float reflectivityIn, float transparencyIn, float refractiveIndexIn) noexcept : color(colorIn), ambient(ambientIn), diffuse(diffuseIn), specular(specularIn), shininess(shininessIn), reflectivity(reflectivityIn), transparency(transparencyIn), refractiveIndex(refractiveIndexIn){};
 
     [[nodiscard]] bool operator==(const Material& other) const noexcept;
-    [[nodiscard]] Color light(const Light& light, const Tuple& position, const Tuple& eyeVector, const Tuple& normalVector, const bool inShadow) const noexcept;
+    [[nodiscard]] Color light(const Light& light, const Tuple& point, const Tuple& eyeVector, const Tuple& normalVector, bool inShadow) const noexcept;
 };
 
 #endif /* SRC_MATERIAL_HPP_ */

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -12,7 +12,7 @@
 #include <array>
 #include <iostream>
 
-#define MATRIX_EPSILON 0.00001f
+#define MATRIX_EPSILON 0.00001F
 
 template <uint32_t N>
 class Matrix
@@ -25,10 +25,10 @@ class Matrix
             row = {};
         }
     }
-    Matrix(std::array<std::array<float, N>, N> initialData) noexcept : data(initialData){};
+    Matrix(const std::array<std::array<float, N>, N>& initialData) noexcept : data(initialData){};
 
-    std::array<float, N>& operator[](const uint32_t index) noexcept;
-    const std::array<float, N>& operator[](const uint32_t index) const noexcept;
+    std::array<float, N>& operator[](uint32_t index) noexcept;
+    const std::array<float, N>& operator[](uint32_t index) const noexcept;
     [[nodiscard]] bool operator==(const Matrix<N>& other) const noexcept;
     [[nodiscard]] bool operator!=(const Matrix<N>& other) const noexcept; // The inequality operator tests passed without this... what?!
     [[nodiscard]] Matrix<N> operator*(const Matrix<N>& other) const noexcept;
@@ -145,7 +145,7 @@ float Matrix<N>::determinant() const noexcept
 }
 
 template <uint32_t N>
-Matrix<N - 1> Matrix<N>::submatrix(uint32_t row, uint32_t col) const noexcept
+Matrix<N - 1> Matrix<N>::submatrix(const uint32_t row, const uint32_t col) const noexcept
 {
     Matrix<N - 1> s;
     uint32_t rowOffset = 0;

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -25,7 +25,7 @@ class Matrix
             row = {};
         }
     }
-    Matrix(const std::array<std::array<float, N>, N>& initialData) noexcept : data(initialData){};
+    explicit Matrix(const std::array<std::array<float, N>, N>& initialData) noexcept : data(initialData){};
 
     std::array<float, N>& operator[](uint32_t index) noexcept;
     const std::array<float, N>& operator[](uint32_t index) const noexcept;

--- a/src/Matrix.hpp
+++ b/src/Matrix.hpp
@@ -12,7 +12,7 @@
 #include <array>
 #include <iostream>
 
-#define MATRIX_EPSILON 0.00001F
+constexpr float MATRIX_EPSILON = 0.00001F;
 
 template <uint32_t N>
 class Matrix

--- a/src/Ray.cpp
+++ b/src/Ray.cpp
@@ -9,7 +9,6 @@
 #define SRC_RAY_CPP_
 
 #include "Ray.hpp"
-
 #include <algorithm>
 #include <cmath>
 
@@ -18,10 +17,11 @@ Tuple Ray::cast(const float t) const noexcept
     return origin + direction * t;
 }
 
-std::optional<Intersection> Ray::hit(std::vector<Intersection> intersections) noexcept
+std::optional<Intersection> Ray::hit(const std::vector<Intersection>& intersections) noexcept
 {
-    std::sort(intersections.begin(), intersections.end());
-    for (const auto intersection : intersections)
+	auto sortedIntersections = intersections;
+    std::sort(sortedIntersections.begin(), sortedIntersections.end());
+    for (const auto intersection : sortedIntersections)
     {
         if (intersection.t > 0)
         {
@@ -36,7 +36,7 @@ Ray Ray::transform(const Matrix<4>& m) const noexcept
     return Ray(m * this->origin, m * this->direction);
 }
 
-IntersectionDetails Ray::precomputeDetails(const Intersection i, const std::vector<Intersection>& intersections) const noexcept
+IntersectionDetails Ray::precomputeDetails(const Intersection& i, const std::vector<Intersection>& intersections) const noexcept
 {
     const Tuple position = cast(i.t);
     const Tuple eyeVector = -direction;
@@ -51,15 +51,15 @@ IntersectionDetails Ray::precomputeDetails(const Intersection i, const std::vect
     const Tuple reflectionVector = direction.reflect(normalVector);
 
     std::vector<Shape> containers;
-    float n1 = 0.0f;
-    float n2 = 0.0f;
+    float n1 = 0.0F;
+    float n2 = 0.0F;
     for (auto intersection : intersections)
     {
         if (i == intersection)
         {
             if (containers.empty())
             {
-                n1 = 1.0f;
+                n1 = 1.0F;
             } else
             {
                 n1 = containers.back().material.refractiveIndex;
@@ -79,7 +79,7 @@ IntersectionDetails Ray::precomputeDetails(const Intersection i, const std::vect
         {
             if (containers.empty())
             {
-                n2 = 1.0f;
+                n2 = 1.0F;
             } else
             {
                 n2 = containers.back().material.refractiveIndex;
@@ -91,7 +91,7 @@ IntersectionDetails Ray::precomputeDetails(const Intersection i, const std::vect
     // Schlick reflectance - Algorithm from "Reflections and Refractions in Ray Tracing" by Bram de Greve
     float cos = eyeVector.dot(normalVector);
     //float reflectance = 0.0f;
-    float sin2T = 0.0f;
+    float sin2T = 0.0F;
     if (n1 > n2)
     {
         const float nRatio = n1 / n2;
@@ -100,10 +100,10 @@ IntersectionDetails Ray::precomputeDetails(const Intersection i, const std::vect
         //    	{
         //    		reflectance = 1.0f;
         //    	}
-        cos = sqrtf(1.0f - sin2T);
+        cos = sqrtf(1.0F - sin2T);
     }
     const float r0 = powf(((n1 - n2) / (n1 + n2)), 2);
-    const float reflectance = sin2T > 1.0f ? 1.0f : r0 + (1 - r0) * powf(1 - cos, 5);
+    const float reflectance = sin2T > 1.0F ? 1.0F : r0 + (1 - r0) * powf(1 - cos, 5);
 
     IntersectionDetails id = {*(i.object), position, overPosition, underPosition, eyeVector, normalVector, reflectionVector, i.t, reflectance, inside, n1, n2};
     return id;

--- a/src/Ray.cpp
+++ b/src/Ray.cpp
@@ -19,7 +19,7 @@ Tuple Ray::cast(const float t) const noexcept
 
 std::optional<Intersection> Ray::hit(const std::vector<Intersection>& intersections) noexcept
 {
-	auto sortedIntersections = intersections;
+    auto sortedIntersections = intersections;
     std::sort(sortedIntersections.begin(), sortedIntersections.end());
     for (const auto intersection : sortedIntersections)
     {

--- a/src/Ray.cpp
+++ b/src/Ray.cpp
@@ -105,7 +105,7 @@ IntersectionDetails Ray::precomputeDetails(const Intersection& i, const std::vec
     const float r0 = powf(((n1 - n2) / (n1 + n2)), 2);
     const float reflectance = sin2T > 1.0F ? 1.0F : r0 + (1 - r0) * powf(1 - cos, 5);
 
-    IntersectionDetails id = {*(i.object), position, overPosition, underPosition, eyeVector, normalVector, reflectionVector, i.t, reflectance, inside, n1, n2};
+    IntersectionDetails id = {position, overPosition, underPosition, eyeVector, normalVector, reflectionVector, *(i.object), i.t, reflectance, inside, n1, n2};
     return id;
 }
 

--- a/src/Ray.hpp
+++ b/src/Ray.hpp
@@ -21,10 +21,10 @@ class Ray
     Tuple direction;
 
     Ray(const Tuple& originIn, const Tuple& directionIn) noexcept : origin(originIn), direction(directionIn){};
-    [[nodiscard]] Tuple cast(const float t) const noexcept;
-    [[nodiscard]] static std::optional<Intersection> hit(const std::vector<Intersection> intersections) noexcept;
+    [[nodiscard]] Tuple cast(float t) const noexcept;
+    [[nodiscard]] static std::optional<Intersection> hit(const std::vector<Intersection>& intersections) noexcept;
     [[nodiscard]] Ray transform(const Matrix<4>& m) const noexcept;
-    [[nodiscard]] IntersectionDetails precomputeDetails(const Intersection i, const std::vector<Intersection>& intersections) const noexcept;
+    [[nodiscard]] IntersectionDetails precomputeDetails(const Intersection& i, const std::vector<Intersection>& intersections) const noexcept;
 };
 
 #endif /* SRC_RAY_HPP_ */

--- a/src/Shape.cpp
+++ b/src/Shape.cpp
@@ -94,22 +94,22 @@ Tuple Cube::objectNormal(const Tuple& p) const noexcept
 
 std::vector<Intersection> Cube::objectIntersect(const Ray& r) const noexcept
 {
-    float xTMin = (-1.0f - r.origin.x) / r.direction.x;
-    float xTMax = (1.0f - r.origin.x) / r.direction.x;
+    float xTMin = (-1.0F - r.origin.x) / r.direction.x;
+    float xTMax = (1.0F - r.origin.x) / r.direction.x;
     if (xTMin > xTMax)
     {
         std::swap(xTMin, xTMax);
     }
 
-    float yTMin = (-1.0f - r.origin.y) / r.direction.y;
-    float yTMax = (1.0f - r.origin.y) / r.direction.y;
+    float yTMin = (-1.0F - r.origin.y) / r.direction.y;
+    float yTMax = (1.0F - r.origin.y) / r.direction.y;
     if (yTMin > yTMax)
     {
         std::swap(yTMin, yTMax);
     }
 
-    float zTMin = (-1.0f - r.origin.z) / r.direction.z;
-    float zTMax = (1.0f - r.origin.z) / r.direction.z;
+    float zTMin = (-1.0F - r.origin.z) / r.direction.z;
+    float zTMax = (1.0F - r.origin.z) / r.direction.z;
     if (zTMin > zTMax)
     {
         std::swap(zTMin, zTMax);
@@ -142,10 +142,10 @@ Tuple Cylinder::objectNormal(const Tuple& p) const noexcept
     const float dist = p.x * p.x + p.z * p.z;
     Tuple normal;
 
-    if (dist < 1.0f && p.y >= maximum - TUPLE_EPSILON)
+    if (dist < 1.0F && p.y >= maximum - TUPLE_EPSILON)
     {
         normal = Vector(0, 1, 0);
-    } else if (dist < 1.0f && p.y <= minimum + TUPLE_EPSILON)
+    } else if (dist < 1.0F && p.y <= minimum + TUPLE_EPSILON)
     {
         normal = Vector(0, -1, 0);
     } else
@@ -187,13 +187,13 @@ std::vector<Intersection> Cylinder::objectIntersect(const Ray& r) const noexcept
     if (closed)
     {
         const float tMin = (minimum - r.origin.y) / r.direction.y;
-        if (std::pow(r.origin.x + tMin * r.direction.x, 2.0f) + std::pow(r.origin.z + tMin * r.direction.z, 2.0f) <= 1.0f)
+        if (std::pow(r.origin.x + tMin * r.direction.x, 2.0F) + std::pow(r.origin.z + tMin * r.direction.z, 2.0F) <= 1.0F)
         {
             i.emplace_back(Intersection(tMin, this));
         }
 
         const float tMax = (maximum - r.origin.y) / r.direction.y;
-        if (std::pow(r.origin.x + tMax * r.direction.x, 2.0f) + std::pow(r.origin.z + tMax * r.direction.z, 2.0f) <= 1.0f)
+        if (std::pow(r.origin.x + tMax * r.direction.x, 2.0F) + std::pow(r.origin.z + tMax * r.direction.z, 2.0F) <= 1.0F)
         {
             i.emplace_back(Intersection(tMax, this));
         }
@@ -216,10 +216,10 @@ Tuple Cone::objectNormal(const Tuple& p) const noexcept
     const float dist = p.x * p.x + p.z * p.z;
     Tuple normal;
 
-    if (dist < 1.0f && p.y >= maximum - TUPLE_EPSILON)
+    if (dist < 1.0F && p.y >= maximum - TUPLE_EPSILON)
     {
         normal = Vector(0, 1, 0);
-    } else if (dist < 1.0f && p.y <= minimum + TUPLE_EPSILON)
+    } else if (dist < 1.0F && p.y <= minimum + TUPLE_EPSILON)
     {
         normal = Vector(0, -1, 0);
     } else
@@ -243,7 +243,7 @@ std::vector<Intersection> Cone::objectIntersect(const Ray& r) const noexcept
     float discriminant = b * b - 4 * a * c;
     if (std::abs(discriminant) < MATRIX_EPSILON)
     {
-        discriminant = 0.0f;
+        discriminant = 0.0F;
     }
 
     if (std::abs(a) > TUPLE_EPSILON && discriminant >= 0)
@@ -271,13 +271,13 @@ std::vector<Intersection> Cone::objectIntersect(const Ray& r) const noexcept
     if (closed)
     {
         const float tMin = (minimum - r.origin.y) / r.direction.y;
-        if (std::pow(r.origin.x + tMin * r.direction.x, 2.0f) + std::pow(r.origin.z + tMin * r.direction.z, 2.0f) <= minimum * minimum)
+        if (std::pow(r.origin.x + tMin * r.direction.x, 2.0F) + std::pow(r.origin.z + tMin * r.direction.z, 2.0F) <= minimum * minimum)
         {
             i.emplace_back(Intersection(tMin, this));
         }
 
         const float tMax = (maximum - r.origin.y) / r.direction.y;
-        if (std::pow(r.origin.x + tMax * r.direction.x, 2.0f) + std::pow(r.origin.z + tMax * r.direction.z, 2.0f) <= maximum * maximum)
+        if (std::pow(r.origin.x + tMax * r.direction.x, 2.0F) + std::pow(r.origin.z + tMax * r.direction.z, 2.0F) <= maximum * maximum)
         {
             i.emplace_back(Intersection(tMax, this));
         }
@@ -289,7 +289,7 @@ std::vector<Intersection> Cone::objectIntersect(const Ray& r) const noexcept
 Sphere GlassSphere() noexcept
 {
     Sphere s;
-    s.material.transparency = 1.0f;
-    s.material.refractiveIndex = 1.5f;
+    s.material.transparency = 1.0F;
+    s.material.refractiveIndex = 1.5F;
     return s;
 }

--- a/src/Shape.cpp
+++ b/src/Shape.cpp
@@ -51,8 +51,8 @@ std::vector<Intersection> Sphere::objectIntersect(const Ray& r) const noexcept
     std::vector<Intersection> intersections;
     if (discriminant >= 0)
     {
-        intersections.push_back(Intersection((-b - sqrtf(discriminant)) / (2 * a), this));
-        intersections.push_back(Intersection((-b + sqrtf(discriminant)) / (2 * a), this));
+        intersections.emplace_back(Intersection((-b - sqrtf(discriminant)) / (2 * a), this));
+        intersections.emplace_back(Intersection((-b + sqrtf(discriminant)) / (2 * a), this));
     }
 
     return intersections;

--- a/src/Shape.hpp
+++ b/src/Shape.hpp
@@ -23,7 +23,7 @@ class Shape
     Matrix<4> transform;
     Material material;
 
-    Shape() noexcept : transform(IdentityMatrix()) {};
+    Shape() noexcept : transform(IdentityMatrix()){};
     virtual ~Shape() noexcept = default;
     Shape(const Shape&) noexcept = default;
     Shape(Shape&&) noexcept = default;

--- a/src/Shape.hpp
+++ b/src/Shape.hpp
@@ -23,7 +23,7 @@ class Shape
     Matrix<4> transform;
     Material material;
 
-    Shape() noexcept : transform(IdentityMatrix()), material(Material()){};
+    Shape() noexcept : transform(IdentityMatrix()) {};
     virtual ~Shape() noexcept = default;
     Shape(const Shape&) noexcept = default;
     Shape(Shape&&) noexcept = default;
@@ -34,13 +34,13 @@ class Shape
 
     [[nodiscard]] Tuple normal(const Tuple& p) const noexcept;
     [[nodiscard]] std::vector<Intersection> intersect(const Ray& r) const noexcept;
-    [[nodiscard]] Color shade(const Light& light, const Tuple& position, const Tuple& eyeVector, const bool inShadow) const noexcept;
+    [[nodiscard]] Color shade(const Light& light, const Tuple& position, const Tuple& eyeVector, bool inShadow) const noexcept;
 
   private:
     // I'd prefer to not define these and have a compile time error if these are used, but *shrug*
     [[nodiscard]] virtual Tuple objectNormal([[maybe_unused]] const Tuple& p) const noexcept
     {
-        return Tuple(0.0f, 0.0f, 0.0f, 0.0f);
+        return Tuple(0.0F, 0.0F, 0.0F, 0.0F);
     }
     [[nodiscard]] virtual std::vector<Intersection> objectIntersect([[maybe_unused]] const Ray& r) const noexcept
     {
@@ -106,7 +106,7 @@ class Intersection
     float t;
     const Shape* object;
 
-    Intersection(const float tIn, const Shape* objectIn) noexcept : t(tIn), object(objectIn){};
+    Intersection(float tIn, const Shape* objectIn) noexcept : t(tIn), object(objectIn){};
     bool operator==(const Intersection& other) const noexcept { return t == other.t && object == other.object; }
     bool operator<(const Intersection& other) const noexcept { return t < other.t; }
 };

--- a/src/Shape.hpp
+++ b/src/Shape.hpp
@@ -111,15 +111,15 @@ class Intersection
     bool operator<(const Intersection& other) const noexcept { return t < other.t; }
 };
 
-struct IntersectionDetails
+struct __attribute__((aligned(128))) IntersectionDetails
 {
-    const Shape& object;
     const Tuple point;
     const Tuple overPoint;
     const Tuple underPoint;
     const Tuple eyeVector;
     const Tuple normalVector;
     const Tuple reflectionVector;
+    const Shape& object;
     const float t;
     const float reflectance;
     const bool inside;

--- a/src/Transformation.cpp
+++ b/src/Transformation.cpp
@@ -9,7 +9,7 @@
 
 #include <cmath>
 
-const Matrix<4> translation(const float x, const float y, const float z) noexcept
+Matrix<4> translation(const float x, const float y, const float z) noexcept
 {
     return Matrix<4>({{{1, 0, 0, x},
                        {0, 1, 0, y},
@@ -17,7 +17,7 @@ const Matrix<4> translation(const float x, const float y, const float z) noexcep
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> scaling(const float x, const float y, const float z) noexcept
+Matrix<4> scaling(const float x, const float y, const float z) noexcept
 {
     return Matrix<4>({{{x, 0, 0, 0},
                        {0, y, 0, 0},
@@ -25,7 +25,7 @@ const Matrix<4> scaling(const float x, const float y, const float z) noexcept
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> rotationX(const float r) noexcept
+Matrix<4> rotationX(const float r) noexcept
 {
     return Matrix<4>({{{1, 0, 0, 0},
                        {0, cosf(r), -sinf(r), 0},
@@ -33,15 +33,15 @@ const Matrix<4> rotationX(const float r) noexcept
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> rotationY(const float r) noexcept
+Matrix<4> rotationY(const float r) noexcept
 {
     return Matrix<4>({{{cosf(r), 0, sinf(r), 0},
-                       {0, 1, 0.f, 0},
+                       {0, 1, 0, 0},
                        {-sinf(r), 0, cosf(r), 0},
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> rotationZ(const float r) noexcept
+Matrix<4> rotationZ(const float r) noexcept
 {
     return Matrix<4>({{{cosf(r), -sinf(r), 0, 0},
                        {sinf(r), cosf(r), 0, 0},
@@ -49,7 +49,7 @@ const Matrix<4> rotationZ(const float r) noexcept
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> shearing(const float xSuby, const float xSubz, const float ySubx, const float ySubz, const float zSubx, const float zSuby) noexcept
+Matrix<4> shearing(const float xSuby, const float xSubz, const float ySubx, const float ySubz, const float zSubx, const float zSuby) noexcept
 {
     return Matrix<4>({{{1, xSuby, xSubz, 0},
                        {ySubx, 1, ySubz, 0},
@@ -57,12 +57,12 @@ const Matrix<4> shearing(const float xSuby, const float xSubz, const float ySubx
                        {0, 0, 0, 1}}});
 }
 
-const Matrix<4> ViewTransform() noexcept
+Matrix<4> ViewTransform() noexcept
 {
     return IdentityMatrix();
 }
 
-const Matrix<4> ViewTransform(const Tuple& from, const Tuple& to, const Tuple& up) noexcept
+Matrix<4> ViewTransform(const Tuple& from, const Tuple& to, const Tuple& up) noexcept
 {
     const Tuple forward = (to - from).normalize();
     const Tuple left = forward.cross(up.normalize());

--- a/src/Transformation.hpp
+++ b/src/Transformation.hpp
@@ -11,13 +11,13 @@
 #include "Matrix.hpp"
 #include "Tuple.hpp"
 
-const Matrix<4> translation(const float x, const float y, const float z) noexcept;
-const Matrix<4> scaling(const float x, const float y, const float z) noexcept;
-const Matrix<4> rotationX(const float r) noexcept;
-const Matrix<4> rotationY(const float r) noexcept;
-const Matrix<4> rotationZ(const float r) noexcept;
-const Matrix<4> shearing(const float xSuby, const float xSubz, const float ySubx, const float ySubz, const float zSubx, const float zSuby) noexcept;
-const Matrix<4> ViewTransform() noexcept;
-const Matrix<4> ViewTransform(const Tuple& from, const Tuple& to, const Tuple& up) noexcept;
+Matrix<4> translation(float x, float y, float z) noexcept;
+Matrix<4> scaling(float x, float y, float z) noexcept;
+Matrix<4> rotationX(float r) noexcept;
+Matrix<4> rotationY(float r) noexcept;
+Matrix<4> rotationZ(float r) noexcept;
+Matrix<4> shearing(float xSuby, float xSubz, float ySubx, float ySubz, float zSubx, float zSuby) noexcept;
+Matrix<4> ViewTransform() noexcept;
+Matrix<4> ViewTransform(const Tuple& from, const Tuple& to, const Tuple& up) noexcept;
 
 #endif /* SRC_TRANSFORMATION_HPP_ */

--- a/src/Tuple.cpp
+++ b/src/Tuple.cpp
@@ -60,7 +60,7 @@ Tuple Tuple::operator/(const float s) const noexcept
 
 bool Tuple::IsPoint() const noexcept
 {
-    return std::abs(this->w - 1.0f) < TUPLE_EPSILON;
+    return std::abs(this->w - 1.0F) < TUPLE_EPSILON;
 }
 
 bool Tuple::IsVector() const noexcept
@@ -96,10 +96,10 @@ Tuple Tuple::reflect(const Tuple& normal) const noexcept
 
 Tuple Point(float xIn, float yIn, float zIn) noexcept
 {
-    return Tuple(xIn, yIn, zIn, 1.0f);
+    return Tuple(xIn, yIn, zIn, 1.0F);
 }
 
 Tuple Vector(float xIn, float yIn, float zIn) noexcept
 {
-    return Tuple(xIn, yIn, zIn, 0.0f);
+    return Tuple(xIn, yIn, zIn, 0.0F);
 }

--- a/src/Tuple.hpp
+++ b/src/Tuple.hpp
@@ -8,7 +8,7 @@
 #ifndef SOURCE_TUPLE_HPP_
 #define SOURCE_TUPLE_HPP_
 
-#define TUPLE_EPSILON 0.002F // Changed to be much much higher since it is now being used for acne removal offset; needed to be this high to work
+constexpr float TUPLE_EPSILON = 0.002F; // Changed to be much much higher since it is now being used for acne removal offset; needed to be this high to work
 
 class Tuple
 {

--- a/src/Tuple.hpp
+++ b/src/Tuple.hpp
@@ -8,35 +8,35 @@
 #ifndef SOURCE_TUPLE_HPP_
 #define SOURCE_TUPLE_HPP_
 
-#define TUPLE_EPSILON 0.002f // Changed to be much much higher since it is now being used for acne removal offset; needed to be this high to work
+#define TUPLE_EPSILON 0.002F // Changed to be much much higher since it is now being used for acne removal offset; needed to be this high to work
 
 class Tuple
 {
   public:
-    float x = 0.0f;
-    float y = 0.0f;
-    float z = 0.0f;
-    float w = 0.0f;
+    float x = 0.0F;
+    float y = 0.0F;
+    float z = 0.0F;
+    float w = 0.0F;
 
     Tuple() noexcept = default;
     Tuple(float xIn, float yIn, float zIn, float wIn) noexcept; // : x(xIn), y(yIn), z(zIn), w(wIn) {};
 
     // Operator overloads
-    bool operator==(const Tuple&) const noexcept;
-    bool operator!=(const Tuple&) const noexcept;
-    Tuple operator+(const Tuple&) const noexcept;
-    Tuple operator-(const Tuple&) const noexcept;
+    bool operator==(const Tuple& other) const noexcept;
+    bool operator!=(const Tuple& other) const noexcept;
+    Tuple operator+(const Tuple& other) const noexcept;
+    Tuple operator-(const Tuple& other) const noexcept;
     Tuple operator-() const noexcept;
-    Tuple operator*(const float) const noexcept;
-    Tuple operator/(const float) const noexcept;
+    Tuple operator*(float s) const noexcept;
+    Tuple operator/(float s) const noexcept;
 
     [[nodiscard]] bool IsPoint() const noexcept;
     [[nodiscard]] bool IsVector() const noexcept;
     [[nodiscard]] float magnitude() const noexcept;
     [[nodiscard]] Tuple normalize() const noexcept;
-    [[nodiscard]] float dot(const Tuple&) const noexcept;
-    [[nodiscard]] Tuple cross(const Tuple&) const noexcept;
-    [[nodiscard]] Tuple reflect(const Tuple&) const noexcept;
+    [[nodiscard]] float dot(const Tuple& other) const noexcept;
+    [[nodiscard]] Tuple cross(const Tuple& other) const noexcept;
+    [[nodiscard]] Tuple reflect(const Tuple& normal) const noexcept;
 };
 
 Tuple Point(float xIn, float yIn, float zIn) noexcept;

--- a/src/Tuple.hpp
+++ b/src/Tuple.hpp
@@ -13,12 +13,12 @@
 class Tuple
 {
   public:
-    float x;
-    float y;
-    float z;
-    float w;
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+    float w = 0.0f;
 
-    Tuple() noexcept : x(0.0f), y(0.0f), z(0.0f), w(0.0f){};
+    Tuple() noexcept = default;
     Tuple(float xIn, float yIn, float zIn, float wIn) noexcept; // : x(xIn), y(yIn), z(zIn), w(wIn) {};
 
     // Operator overloads

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -13,12 +13,12 @@
 World World::BaseWorld() noexcept
 {
     Sphere s1;
-    s1.material.color = Color(0.8f, 1.0f, 0.6f);
-    s1.material.diffuse = 0.7f;
-    s1.material.specular = 0.2f;
+    s1.material.color = Color(0.8F, 1.0F, 0.6F);
+    s1.material.diffuse = 0.7F;
+    s1.material.specular = 0.2F;
 
     Sphere s2;
-    s2.transform = scaling(0.5, 0.5, 0.5);
+    s2.transform = scaling(0.5F, 0.5F, 0.5F);
 
     World w;
     w.spheres.push_back(s1);
@@ -79,7 +79,7 @@ Color World::shadeHit(const IntersectionDetails& id, int remainingCalls) const n
     const Color refracted = refractedColor(id, remainingCalls);
 
     Color finalColor;
-    if (id.object.material.reflectivity > 0.0f && id.object.material.transparency > 0.0f)
+    if (id.object.material.reflectivity > 0.0F && id.object.material.transparency > 0.0F)
     {
         finalColor = surface + reflected * id.reflectance + refracted * (1 - id.reflectance);
     } else
@@ -92,7 +92,7 @@ Color World::shadeHit(const IntersectionDetails& id, int remainingCalls) const n
 Color World::reflectedColor(const IntersectionDetails& id, int remainingCalls) const noexcept
 {
     // Early out if object is not reflective or max recursion depth reached
-    if (id.object.material.reflectivity == 0.0f || remainingCalls < 1)
+    if (id.object.material.reflectivity == 0.0F || remainingCalls < 1)
     {
         return Color::Black;
     }
@@ -114,12 +114,12 @@ Color World::refractedColor(const IntersectionDetails& id, int remainingCalls) c
     const float nRatio = id.n1 / id.n2;
     const float cosI = id.eyeVector.dot(id.normalVector);
     const float sin2T = nRatio * nRatio * (1 - cosI * cosI);
-    if (sin2T >= 1.0f)
+    if (sin2T >= 1.0F)
     {
         return Color::Black;
     }
 
-    const float cosT = sqrtf(1.0f - sin2T);
+    const float cosT = sqrtf(1.0F - sin2T);
     const Tuple refractionDirection = id.normalVector * (nRatio * cosI - cosT) - id.eyeVector * nRatio;
     const Ray refractionRay = Ray(id.underPoint, refractionDirection);
     return colorAt(refractionRay, remainingCalls - 1) * id.object.material.transparency;
@@ -137,13 +137,7 @@ Color World::colorAt(Ray r, int remainingCalls) const noexcept
         }
     }
     auto hit = Ray::hit(intersections);
-    if (hit)
-    {
-        return shadeHit(r.precomputeDetails(*hit, intersections), remainingCalls);
-    } else
-    {
-        return {0, 0, 0};
-    }
+    return hit ? shadeHit(r.precomputeDetails(*hit, intersections), remainingCalls) : Color(0, 0, 0);
 }
 
 bool World::isShadowed(const Tuple& point) const noexcept
@@ -152,7 +146,7 @@ bool World::isShadowed(const Tuple& point) const noexcept
     const float distanceToLight = (light.position - point).magnitude();
     const Ray shadowRay = Ray(point, shadowVector);
     const auto intersections = intersect(shadowRay);
-    const auto hit = shadowRay.hit(intersections);
+    const auto hit = Ray::hit(intersections);
 
     const bool shadowed = hit && hit->t < distanceToLight;
     return shadowed;


### PR DESCRIPTION
Go through full list of clang-tidy checks and add all that make sense.

- fuchsia-*, zircon-*, abseil-*, and modernize-use-trailing-return-type ignored based on guidance from Jason Turner
- llvm-header-guard, and llvmlibc-* ignored because they don't make sense in the context of this project
- readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers, cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-non-private-member-variables-in-classes, misc-non-private-member-variables-in-classes, and misc-no-recursion ignored because it would take non-trivial refactoring to implement at the moment